### PR TITLE
[V10 Compat]Remove unused languages section

### DIFF
--- a/module.json
+++ b/module.json
@@ -12,13 +12,6 @@
     "scripts": [],
     "esmodules": [],
     "styles": [],
-    "languages": [
-        {
-            "lang": "en",
-            "name": "English",
-            "path": "lang/en.json"
-        }
-    ],
     "packs": [
 	{
             "name": "shuggaloafs-sng-macros",


### PR DESCRIPTION
it provokes an error when installing in V10. Without this, it installs fine.